### PR TITLE
refactor(typing)!: add typescript definition file

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -1,0 +1,215 @@
+export as namespace zxcvbn;
+
+export = zxcvbn;
+
+declare function zxcvbn(
+  password: string,
+  userInputs?: string[]
+): zxcvbn.ZXCVBNResult;
+
+declare module zxcvbn {
+  export function set_frequency_lists(lists: ZXCVBNFrequencyLists): void;
+
+  export interface ZXCVBNResult {
+    /**
+     * estimated guesses needed to crack password
+     */
+    guesses: number;
+
+    /**
+     * order of magnitude of result.guesses
+     */
+    guesses_log10: number;
+
+    /**
+     * dictionary of back-of-the-envelope crack time
+     * estimations, in seconds, based on a few scenarios.
+     */
+    crack_times_seconds: ZXCVBNAttackTime<number>;
+
+    /**
+     * same keys as result.crack_times_seconds,
+     * with friendlier display string values:
+     * "less than a second", "3 hours", "centuries", etc.
+     */
+    crack_times_display: ZXCVBNAttackTime<string>;
+
+    /**
+     * Integer from 0-4 (useful for implementing a strength bar):
+     * 0 too guessable: risky password. (guesses < 10^3)
+     * 1 very guessable: protection from throttled online attacks. (guesses < 10^6)
+     * 2 somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)
+     * 3 safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)
+     * 4 very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
+     */
+    score: ZXCVBNScore;
+
+    /**
+     * verbal feedback to help choose better passwords. set when score <= 2.
+     */
+    feedback: ZXCVBNFeedback;
+
+    /**
+     * the list of patterns that zxcvbn based the
+     * guess calculation on.
+     */
+    sequence: ZXCVBNSequence[];
+
+    /**
+     * how long it took zxcvbn to calculate an answer,
+     * in milliseconds.
+     */
+    calc_time: number;
+  }
+
+  export type ZXCVBNScore = 0 | 1 | 2 | 3 | 4;
+
+  export interface ZXCVBNAttackTime<T extends string | number> {
+    /**
+     * online attack on a service that ratelimits password auth attempts.
+     */
+    online_throttling_100_per_hour: T;
+
+    /**
+     * online attack on a service that doesn't ratelimit,
+     * or where an attacker has outsmarted ratelimiting.
+     */
+    online_no_throttling_10_per_second: T;
+
+    /**
+     * offline attack. assumes multiple attackers,
+     * proper user-unique salting, and a slow hash function
+     * w/ moderate work factor, such as bcrypt, scrypt, PBKDF2.
+     */
+    offline_slow_hashing_1e4_per_second: T;
+
+    /**
+     * offline attack with user-unique salting but a fast hash
+     * function like SHA-1, SHA-256 or MD5. A wide range of
+     * reasonable numbers anywhere from one billion - one trillion
+     * guesses per second, depending on number of cores and machines.
+     * ballparking at 10B/sec.
+     */
+    offline_fast_hashing_1e10_per_second: T;
+  }
+
+  export interface ZXCVBNFeedback {
+    /**
+     * explains what's wrong, eg. 'this is a top-10 common password'.
+     * not always set -- sometimes an empty string
+     */
+    warning: string;
+
+    /**
+     * a possibly-empty list of suggestions to help choose a less
+     * guessable password. eg. 'Add another word or two'
+     */
+    suggestions: string[];
+  }
+
+  export interface ZXCVBNSequence {
+    /**
+     * if sequence is ascending.
+     */
+    ascending: boolean;
+
+    /**
+     * the base number of guesses.
+     */
+    base_guesses: number;
+
+    /**
+     * the base match to relate to.
+     */
+    base_matches: string;
+
+    /**
+     * the base token to relate to.
+     */
+    base_token: string;
+
+    /**
+     * the dictionary this sequence was found in.
+     */
+    dictionary_name: string;
+
+    /**
+     * estimated guesses needed to crack sequence.
+     */
+    guesses: number;
+
+    /**
+     * order of magnitude of guesses.
+     */
+    guesses_log10: number;
+
+    /**
+     * sequence index.
+     */
+    i: number;
+
+    /**
+     * sequence section number.
+     */
+    j: number;
+
+    /**
+     * is part of l33t speak.
+     */
+    l33t: boolean;
+
+    /**
+     * how many variations of l33t speak.
+     */
+    l33t_variations: number;
+
+    /**
+     * the word that was matched in dictionary.
+     */
+    matched_word: string;
+
+    /**
+     * what type of pattern the sequence contains.
+     */
+    pattern: string;
+
+    /**
+     * the rank of the sequence in the dictionary.
+     */
+    rank: number;
+
+    /**
+     * how many times the sequence is repeated.
+     */
+    repeat_count: number;
+
+    /**
+     * is reveresed.
+     */
+    reversed: boolean;
+
+    /**
+     * what type of sequence it is.
+     */
+    sequence_name: string;
+
+    /**
+     * how much space the sequence has left.
+     */
+    sequence_space: number;
+
+    /**
+     * the token the sequence is based off.
+     */
+    token: string;
+
+    /**
+     * uppercase variations of the token.
+     */
+    uppercase_variations: number;
+  }
+
+  export interface ZXCVBNFrequencyLists {
+    [name: string]: string[];
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "author": "Dan Wheeler",
   "license": "MIT",
   "main": "lib/main.js",
+  "types": "lib/main.d.ts",
   "repository": "dropbox/zxcvbn",
   "scripts": {
     "test": "coffeetape test/*.coffee | faucet",
     "test-saucelabs": "zuul -- test/*.coffee",
-    "build": "npm run build-lib ; npm run build-dist ; npm run build-json",
+    "build": "npm run build-lib ; npm run build-dist ; npm run build-json ; cp src/main.d.ts lib/",
     "watch": "npm run watch-lib & npm run watch-dist",
     "build-lib": "coffee -o lib --compile --bare --map src/*.coffee",
     "watch-lib": "coffee -o lib --compile --bare --map --watch src/*.coffee",

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,0 +1,215 @@
+export as namespace zxcvbn;
+
+export = zxcvbn;
+
+declare function zxcvbn(
+  password: string,
+  userInputs?: string[]
+): zxcvbn.ZXCVBNResult;
+
+declare module zxcvbn {
+  export function set_frequency_lists(lists: ZXCVBNFrequencyLists): void;
+
+  export interface ZXCVBNResult {
+    /**
+     * estimated guesses needed to crack password
+     */
+    guesses: number;
+
+    /**
+     * order of magnitude of result.guesses
+     */
+    guesses_log10: number;
+
+    /**
+     * dictionary of back-of-the-envelope crack time
+     * estimations, in seconds, based on a few scenarios.
+     */
+    crack_times_seconds: ZXCVBNAttackTime<number>;
+
+    /**
+     * same keys as result.crack_times_seconds,
+     * with friendlier display string values:
+     * "less than a second", "3 hours", "centuries", etc.
+     */
+    crack_times_display: ZXCVBNAttackTime<string>;
+
+    /**
+     * Integer from 0-4 (useful for implementing a strength bar):
+     * 0 too guessable: risky password. (guesses < 10^3)
+     * 1 very guessable: protection from throttled online attacks. (guesses < 10^6)
+     * 2 somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)
+     * 3 safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)
+     * 4 very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
+     */
+    score: ZXCVBNScore;
+
+    /**
+     * verbal feedback to help choose better passwords. set when score <= 2.
+     */
+    feedback: ZXCVBNFeedback;
+
+    /**
+     * the list of patterns that zxcvbn based the
+     * guess calculation on.
+     */
+    sequence: ZXCVBNSequence[];
+
+    /**
+     * how long it took zxcvbn to calculate an answer,
+     * in milliseconds.
+     */
+    calc_time: number;
+  }
+
+  export type ZXCVBNScore = 0 | 1 | 2 | 3 | 4;
+
+  export interface ZXCVBNAttackTime<T extends string | number> {
+    /**
+     * online attack on a service that ratelimits password auth attempts.
+     */
+    online_throttling_100_per_hour: T;
+
+    /**
+     * online attack on a service that doesn't ratelimit,
+     * or where an attacker has outsmarted ratelimiting.
+     */
+    online_no_throttling_10_per_second: T;
+
+    /**
+     * offline attack. assumes multiple attackers,
+     * proper user-unique salting, and a slow hash function
+     * w/ moderate work factor, such as bcrypt, scrypt, PBKDF2.
+     */
+    offline_slow_hashing_1e4_per_second: T;
+
+    /**
+     * offline attack with user-unique salting but a fast hash
+     * function like SHA-1, SHA-256 or MD5. A wide range of
+     * reasonable numbers anywhere from one billion - one trillion
+     * guesses per second, depending on number of cores and machines.
+     * ballparking at 10B/sec.
+     */
+    offline_fast_hashing_1e10_per_second: T;
+  }
+
+  export interface ZXCVBNFeedback {
+    /**
+     * explains what's wrong, eg. 'this is a top-10 common password'.
+     * not always set -- sometimes an empty string
+     */
+    warning: string;
+
+    /**
+     * a possibly-empty list of suggestions to help choose a less
+     * guessable password. eg. 'Add another word or two'
+     */
+    suggestions: string[];
+  }
+
+  export interface ZXCVBNSequence {
+    /**
+     * if sequence is ascending.
+     */
+    ascending: boolean;
+
+    /**
+     * the base number of guesses.
+     */
+    base_guesses: number;
+
+    /**
+     * the base match to relate to.
+     */
+    base_matches: string;
+
+    /**
+     * the base token to relate to.
+     */
+    base_token: string;
+
+    /**
+     * the dictionary this sequence was found in.
+     */
+    dictionary_name: string;
+
+    /**
+     * estimated guesses needed to crack sequence.
+     */
+    guesses: number;
+
+    /**
+     * order of magnitude of guesses.
+     */
+    guesses_log10: number;
+
+    /**
+     * sequence index.
+     */
+    i: number;
+
+    /**
+     * sequence section number.
+     */
+    j: number;
+
+    /**
+     * is part of l33t speak.
+     */
+    l33t: boolean;
+
+    /**
+     * how many variations of l33t speak.
+     */
+    l33t_variations: number;
+
+    /**
+     * the word that was matched in dictionary.
+     */
+    matched_word: string;
+
+    /**
+     * what type of pattern the sequence contains.
+     */
+    pattern: string;
+
+    /**
+     * the rank of the sequence in the dictionary.
+     */
+    rank: number;
+
+    /**
+     * how many times the sequence is repeated.
+     */
+    repeat_count: number;
+
+    /**
+     * is reveresed.
+     */
+    reversed: boolean;
+
+    /**
+     * what type of sequence it is.
+     */
+    sequence_name: string;
+
+    /**
+     * how much space the sequence has left.
+     */
+    sequence_space: number;
+
+    /**
+     * the token the sequence is based off.
+     */
+    token: string;
+
+    /**
+     * uppercase variations of the token.
+     */
+    uppercase_variations: number;
+  }
+
+  export interface ZXCVBNFrequencyLists {
+    [name: string]: string[];
+  }
+}


### PR DESCRIPTION
As we are using this fork in typescript projects, we thought that we needed typing directly on the package to avoid redeclaring the interfaces on each consumer of ZXCVBN.

The interfaces and names are taken directly from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/zxcvbn/index.d.ts with a slight modification for our `set_frequency_list` function that was extracted.

Concerning the fact that we have two files in here is due to the fact that all files generated in `lib` were kept in the repo previously, so I followed the convention on this repo and pushed it too.